### PR TITLE
Remove target_include_directories and target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,5 @@ add_library(core STATIC ${SOURCES})
 # Executable
 add_executable(BackTest-Cpp ${SOURCES} ${HEADERS})
 
-target_link_libraries(BackTest-Cpp PRIVATE core)
-
 # Recursively build other projects.
 add_subdirectory(Examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,5 @@ add_executable(BackTest-Cpp ${SOURCES} ${HEADERS})
 
 target_link_libraries(BackTest-Cpp PRIVATE core)
 
-target_include_directories(core PUBLIC ${CMAKE_SOURCE_DIR}/include)
-
 # Recursively build other projects.
 add_subdirectory(Examples)


### PR DESCRIPTION
This line isn't needed since we have the general include_directories line above. target_link_libraries also isn't needed since Backtest-Cpp is being built with sources and headers.